### PR TITLE
Add persistent settings support for Java Envio client

### DIFF
--- a/java/envio/pom.xml
+++ b/java/envio/pom.xml
@@ -25,6 +25,12 @@
             <artifactId>flatlaf</artifactId>
             <version>3.2.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.34</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/java/envio/src/main/java/cl/prezdev/envio/App.java
+++ b/java/envio/src/main/java/cl/prezdev/envio/App.java
@@ -73,7 +73,7 @@ public class App {
         JMenu settingsMenu = new JMenu("Configuración");
         JMenuItem editSettings = new JMenuItem("Editar ajustes...");
         editSettings.addActionListener(e -> {
-            SettingsDialog dialog = new SettingsDialog(frame, settings, updated -> {
+            SettingsDialog dialog = new SettingsDialog(frame, settings, SETTINGS_MANAGER.getSettingsPath(), updated -> {
                 panel.applySettings();
                 applyWindowSize(frame, updated);
                 updateScaleMenuSelection(updated.getUiScale());

--- a/java/envio/src/main/java/cl/prezdev/envio/App.java
+++ b/java/envio/src/main/java/cl/prezdev/envio/App.java
@@ -3,9 +3,15 @@ package cl.prezdev.envio;
 import com.formdev.flatlaf.FlatDarculaLaf;
 
 import javax.swing.*;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
 import java.util.LinkedHashMap;
 import java.util.Map;
+
 public class App {
+
+    private static final SettingsManager SETTINGS_MANAGER = new SettingsManager();
+    private static final Map<Float, JRadioButtonMenuItem> SCALE_MENU_ITEMS = new LinkedHashMap<>();
 
     public static void main(String[] args) {
         SwingUtilities.invokeLater(App::createAndShowUI);
@@ -16,15 +22,29 @@ public class App {
 
         JFrame frame = new JFrame("HTTP Client Viewer");
         frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
-        HttpClientPanel panel = new HttpClientPanel();
+        Settings settings = SETTINGS_MANAGER.load();
+        HttpClientPanel panel = new HttpClientPanel(settings, App::saveSettings);
         frame.setContentPane(panel);
-        frame.setJMenuBar(createMenuBar(panel));
-        frame.pack();
+        frame.setJMenuBar(createMenuBar(panel, frame, settings));
+        applyWindowSize(frame, settings);
+        panel.applySettings();
+        frame.addComponentListener(new ComponentAdapter() {
+            @Override
+            public void componentResized(ComponentEvent e) {
+                if (!frame.isShowing()) {
+                    return;
+                }
+                settings.setWindowWidth(frame.getWidth());
+                settings.setWindowHeight(frame.getHeight());
+                saveSettings(settings);
+            }
+        });
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
+        updateScaleMenuSelection(settings.getUiScale());
     }
 
-    private static JMenuBar createMenuBar(HttpClientPanel panel) {
+    private static JMenuBar createMenuBar(HttpClientPanel panel, JFrame frame, Settings settings) {
         JMenuBar menuBar = new JMenuBar();
 
         JMenu viewMenu = new JMenu("Ver");
@@ -35,19 +55,59 @@ public class App {
         scales.put("Mediano", 1.25f);
         scales.put("Grande", 1.5f);
 
+        SCALE_MENU_ITEMS.clear();
         ButtonGroup group = new ButtonGroup();
-        boolean first = true;
         for (Map.Entry<String, Float> entry : scales.entrySet()) {
             JRadioButtonMenuItem item = new JRadioButtonMenuItem(entry.getKey());
-            if (first) {
-                item.setSelected(true);
-                first = false;
-            }
-            item.addActionListener(e -> panel.setUiScale(entry.getValue()));
+            float scale = entry.getValue();
+            item.addActionListener(e -> {
+                panel.setUiScale(scale);
+                saveSettings(settings);
+                updateScaleMenuSelection(scale);
+            });
             group.add(item);
+            SCALE_MENU_ITEMS.put(entry.getValue(), item);
             viewMenu.add(item);
         }
 
+        JMenu settingsMenu = new JMenu("Configuración");
+        JMenuItem editSettings = new JMenuItem("Editar ajustes...");
+        editSettings.addActionListener(e -> {
+            SettingsDialog dialog = new SettingsDialog(frame, settings, updated -> {
+                panel.applySettings();
+                applyWindowSize(frame, updated);
+                updateScaleMenuSelection(updated.getUiScale());
+                saveSettings(updated);
+            });
+            dialog.setVisible(true);
+        });
+        settingsMenu.add(editSettings);
+        menuBar.add(settingsMenu);
+
         return menuBar;
+    }
+
+    private static void updateScaleMenuSelection(float scale) {
+        SCALE_MENU_ITEMS.forEach((value, item) -> {
+            if (Math.abs(value - scale) < 0.001f) {
+                item.setSelected(true);
+            } else {
+                item.setSelected(false);
+            }
+        });
+    }
+
+    private static void applyWindowSize(JFrame frame, Settings settings) {
+        int width = settings.getWindowWidth();
+        int height = settings.getWindowHeight();
+        if (width > 0 && height > 0) {
+            frame.setSize(width, height);
+        } else {
+            frame.pack();
+        }
+    }
+
+    private static void saveSettings(Settings settings) {
+        SETTINGS_MANAGER.save(settings);
     }
 }

--- a/java/envio/src/main/java/cl/prezdev/envio/HttpClientPanel.java
+++ b/java/envio/src/main/java/cl/prezdev/envio/HttpClientPanel.java
@@ -211,10 +211,26 @@ public class HttpClientPanel extends JPanel {
         float scaledSize = baseMonospacedFont.getSize2D() * uiScale * componentScale;
         Font codeFont = baseMonospacedFont.deriveFont(scaledSize);
         component.setFont(codeFont);
+        if (component == jsonResponsePane) {
+            updateJsonStyles(codeFont);
+        }
         if (component instanceof JTree tree) {
             int rowHeight = Math.max(16, Math.round(codeFont.getSize2D() * 1.4f));
             tree.setRowHeight(rowHeight);
         }
+    }
+
+    private void updateJsonStyles(Font font) {
+        applyFontToStyle(defaultStyle, font);
+        applyFontToStyle(keyStyle, font);
+        applyFontToStyle(stringStyle, font);
+        applyFontToStyle(numberStyle, font);
+        applyFontToStyle(literalStyle, font);
+    }
+
+    private void applyFontToStyle(Style style, Font font) {
+        StyleConstants.setFontFamily(style, font.getFamily());
+        StyleConstants.setFontSize(style, Math.round(font.getSize2D()));
     }
 
     public void applySettings() {

--- a/java/envio/src/main/java/cl/prezdev/envio/HttpClientPanel.java
+++ b/java/envio/src/main/java/cl/prezdev/envio/HttpClientPanel.java
@@ -8,11 +8,13 @@ import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.DefaultStyledDocument;
+import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.Style;
 import javax.swing.text.StyleConstants;
 import javax.swing.text.StyleContext;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.DefaultTreeCellRenderer;
 import java.awt.*;
 import java.awt.event.ItemEvent;
 import java.util.LinkedHashMap;
@@ -213,6 +215,7 @@ public class HttpClientPanel extends JPanel {
         component.setFont(codeFont);
         if (component == jsonResponsePane) {
             updateJsonStyles(codeFont);
+            refreshJsonDocumentFont(codeFont);
         }
         if (component instanceof JTree tree) {
             int rowHeight = Math.max(16, Math.round(codeFont.getSize2D() * 1.4f));
@@ -231,6 +234,13 @@ public class HttpClientPanel extends JPanel {
     private void applyFontToStyle(Style style, Font font) {
         StyleConstants.setFontFamily(style, font.getFamily());
         StyleConstants.setFontSize(style, Math.round(font.getSize2D()));
+    }
+
+    private void refreshJsonDocumentFont(Font font) {
+        SimpleAttributeSet attributes = new SimpleAttributeSet();
+        StyleConstants.setFontFamily(attributes, font.getFamily());
+        StyleConstants.setFontSize(attributes, Math.round(font.getSize2D()));
+        jsonDocument.setCharacterAttributes(0, jsonDocument.getLength(), attributes, false);
     }
 
     public void applySettings() {
@@ -401,6 +411,16 @@ public class HttpClientPanel extends JPanel {
         tree.setRootVisible(true);
         tree.setShowsRootHandles(true);
         tree.setFont(baseMonospacedFont);
+        tree.setCellRenderer(new DefaultTreeCellRenderer() {
+            @Override
+            public Component getTreeCellRendererComponent(JTree tree, Object value, boolean sel,
+                                                          boolean expanded, boolean leaf, int row,
+                                                          boolean hasFocus) {
+                Component component = super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, hasFocus);
+                component.setFont(tree.getFont());
+                return component;
+            }
+        });
         return tree;
     }
 

--- a/java/envio/src/main/java/cl/prezdev/envio/Settings.java
+++ b/java/envio/src/main/java/cl/prezdev/envio/Settings.java
@@ -3,14 +3,20 @@ package cl.prezdev.envio;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+@Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Settings {
+    @Setter
     private float uiScale = 1.0f;
+    @Setter
     private int windowWidth = -1;
+    @Setter
     private int windowHeight = -1;
     private final Map<String, Float> componentScales = new LinkedHashMap<>();
 
@@ -38,34 +44,6 @@ public class Settings {
         this.windowHeight = other.windowHeight;
         this.componentScales.clear();
         this.componentScales.putAll(other.componentScales);
-    }
-
-    public float getUiScale() {
-        return uiScale;
-    }
-
-    public void setUiScale(float uiScale) {
-        this.uiScale = uiScale;
-    }
-
-    public int getWindowWidth() {
-        return windowWidth;
-    }
-
-    public void setWindowWidth(int windowWidth) {
-        this.windowWidth = windowWidth;
-    }
-
-    public int getWindowHeight() {
-        return windowHeight;
-    }
-
-    public void setWindowHeight(int windowHeight) {
-        this.windowHeight = windowHeight;
-    }
-
-    public Map<String, Float> getComponentScales() {
-        return componentScales;
     }
 
     @JsonIgnore

--- a/java/envio/src/main/java/cl/prezdev/envio/Settings.java
+++ b/java/envio/src/main/java/cl/prezdev/envio/Settings.java
@@ -1,0 +1,84 @@
+package cl.prezdev.envio;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Settings {
+    private float uiScale = 1.0f;
+    private int windowWidth = -1;
+    private int windowHeight = -1;
+    private final Map<String, Float> componentScales = new LinkedHashMap<>();
+
+    public Settings() {
+    }
+
+    public static Settings defaults() {
+        Settings settings = new Settings();
+        settings.uiScale = 1.0f;
+        return settings;
+    }
+
+    public Settings copy() {
+        Settings copy = new Settings();
+        copy.uiScale = uiScale;
+        copy.windowWidth = windowWidth;
+        copy.windowHeight = windowHeight;
+        copy.componentScales.putAll(componentScales);
+        return copy;
+    }
+
+    public void copyFrom(Settings other) {
+        this.uiScale = other.uiScale;
+        this.windowWidth = other.windowWidth;
+        this.windowHeight = other.windowHeight;
+        this.componentScales.clear();
+        this.componentScales.putAll(other.componentScales);
+    }
+
+    public float getUiScale() {
+        return uiScale;
+    }
+
+    public void setUiScale(float uiScale) {
+        this.uiScale = uiScale;
+    }
+
+    public int getWindowWidth() {
+        return windowWidth;
+    }
+
+    public void setWindowWidth(int windowWidth) {
+        this.windowWidth = windowWidth;
+    }
+
+    public int getWindowHeight() {
+        return windowHeight;
+    }
+
+    public void setWindowHeight(int windowHeight) {
+        this.windowHeight = windowHeight;
+    }
+
+    public Map<String, Float> getComponentScales() {
+        return componentScales;
+    }
+
+    @JsonIgnore
+    public float getComponentScale(String id) {
+        return componentScales.getOrDefault(id, 1.0f);
+    }
+
+    public void setComponentScale(String id, float scale) {
+        componentScales.put(id, scale);
+    }
+
+    @JsonAnySetter
+    public void setDynamicProperty(String key, Object value) {
+        // Allow forward compatibility by ignoring unknown fields instead of failing.
+    }
+}

--- a/java/envio/src/main/java/cl/prezdev/envio/SettingsDialog.java
+++ b/java/envio/src/main/java/cl/prezdev/envio/SettingsDialog.java
@@ -1,0 +1,179 @@
+package cl.prezdev.envio;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import javax.swing.*;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import java.awt.*;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class SettingsDialog extends JDialog {
+    private final Settings settings;
+    private final Settings workingCopy;
+    private final Consumer<Settings> onApply;
+    private final Map<String, JSpinner> componentSpinners = new LinkedHashMap<>();
+    private final JSpinner uiScaleSpinner;
+    private final JSpinner widthSpinner;
+    private final JSpinner heightSpinner;
+    private final JTextArea jsonEditor;
+    private final ObjectMapper mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+
+    public SettingsDialog(Frame owner, Settings settings, Consumer<Settings> onApply) {
+        super(owner, "Ajustes", true);
+        this.settings = settings;
+        this.workingCopy = settings.copy();
+        this.onApply = onApply;
+
+        setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+        setLayout(new BorderLayout(12, 12));
+
+        JTabbedPane tabs = new JTabbedPane();
+        tabs.addTab("Gráfico", createVisualPanel());
+        tabs.addTab("JSON", createJsonPanel());
+        tabs.addChangeListener(e -> {
+            if (tabs.getSelectedIndex() == 1) {
+                refreshJsonEditor();
+            }
+        });
+        add(tabs, BorderLayout.CENTER);
+
+        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        JButton cancelButton = new JButton("Cancelar");
+        cancelButton.addActionListener(e -> dispose());
+        JButton saveButton = new JButton("Guardar");
+        saveButton.addActionListener(e -> onSave());
+        buttonPanel.add(cancelButton);
+        buttonPanel.add(saveButton);
+        add(buttonPanel, BorderLayout.SOUTH);
+
+        pack();
+        setLocationRelativeTo(owner);
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowOpened(WindowEvent e) {
+                refreshJsonEditor();
+            }
+        });
+    }
+
+    private JPanel createVisualPanel() {
+        JPanel panel = new JPanel(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(4, 4, 4, 4);
+        gbc.anchor = GridBagConstraints.WEST;
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+
+        panel.add(new JLabel("Escala de interfaz"), gbc);
+        gbc.gridx = 1;
+        uiScaleSpinner = new JSpinner(new SpinnerNumberModel((double) workingCopy.getUiScale(), 0.5, 2.5, 0.05));
+        workingCopy.setUiScale(((Double) uiScaleSpinner.getValue()).floatValue());
+        uiScaleSpinner.addChangeListener(spinnerListener(value -> workingCopy.setUiScale(value.floatValue())));
+        panel.add(uiScaleSpinner, gbc);
+
+        gbc.gridx = 0;
+        gbc.gridy++;
+        panel.add(new JLabel("Ancho de ventana"), gbc);
+        gbc.gridx = 1;
+        int widthValue = Math.max(workingCopy.getWindowWidth(), 800);
+        widthSpinner = new JSpinner(new SpinnerNumberModel(widthValue, 400, 4096, 10));
+        workingCopy.setWindowWidth((Integer) widthSpinner.getValue());
+        widthSpinner.addChangeListener(spinnerListener(value -> workingCopy.setWindowWidth(value.intValue())));
+        panel.add(widthSpinner, gbc);
+
+        gbc.gridx = 0;
+        gbc.gridy++;
+        panel.add(new JLabel("Alto de ventana"), gbc);
+        gbc.gridx = 1;
+        int heightValue = Math.max(workingCopy.getWindowHeight(), 600);
+        heightSpinner = new JSpinner(new SpinnerNumberModel(heightValue, 300, 2160, 10));
+        workingCopy.setWindowHeight((Integer) heightSpinner.getValue());
+        heightSpinner.addChangeListener(spinnerListener(value -> workingCopy.setWindowHeight(value.intValue())));
+        panel.add(heightSpinner, gbc);
+
+        gbc.gridx = 0;
+        gbc.gridy++;
+        gbc.gridwidth = 2;
+        panel.add(new JLabel("Zoom por componente"), gbc);
+
+        gbc.gridy++;
+        gbc.gridwidth = 1;
+
+        Map<String, String> labels = Map.of(
+                "requestBody", "Cuerpo de solicitud",
+                "rawRequest", "Request crudo",
+                "rawResponse", "Response crudo",
+                "jsonResponse", "JSON formateado",
+                "jsonTree", "Árbol JSON"
+        );
+
+        for (Map.Entry<String, String> entry : labels.entrySet()) {
+            gbc.gridx = 0;
+            panel.add(new JLabel(entry.getValue()), gbc);
+            gbc.gridx = 1;
+            double scaleValue = workingCopy.getComponentScale(entry.getKey());
+            JSpinner spinner = new JSpinner(new SpinnerNumberModel(scaleValue, 0.5, 3.0, 0.05));
+            workingCopy.setComponentScale(entry.getKey(), ((Double) spinner.getValue()).floatValue());
+            spinner.addChangeListener(spinnerListener(value -> workingCopy.setComponentScale(entry.getKey(), value.floatValue())));
+            componentSpinners.put(entry.getKey(), spinner);
+            panel.add(spinner, gbc);
+            gbc.gridy++;
+        }
+
+        return panel;
+    }
+
+    private JPanel createJsonPanel() {
+        JPanel panel = new JPanel(new BorderLayout());
+        jsonEditor = new JTextArea(20, 60);
+        jsonEditor.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
+        panel.add(new JScrollPane(jsonEditor), BorderLayout.CENTER);
+        JLabel infoLabel = new JLabel("Modifique el JSON y presione Guardar para aplicar los cambios.");
+        panel.add(infoLabel, BorderLayout.SOUTH);
+        return panel;
+    }
+
+    private ChangeListener spinnerListener(Consumer<Number> consumer) {
+        return new ChangeListener() {
+            @Override
+            public void stateChanged(ChangeEvent e) {
+                Object value = ((JSpinner) e.getSource()).getValue();
+                if (value instanceof Number number) {
+                    consumer.accept(number);
+                    refreshJsonEditor();
+                }
+            }
+        };
+    }
+
+    private void refreshJsonEditor() {
+        try {
+            jsonEditor.setText(mapper.writeValueAsString(workingCopy));
+        } catch (IOException e) {
+            jsonEditor.setText("{}");
+        }
+    }
+
+    private void onSave() {
+        try {
+            Settings parsed = mapper.readValue(jsonEditor.getText(), Settings.class);
+            settings.copyFrom(parsed);
+            if (onApply != null) {
+                onApply.accept(settings);
+            }
+            dispose();
+        } catch (IOException ex) {
+            JOptionPane.showMessageDialog(this,
+                    "No se pudo interpretar el JSON ingresado: " + ex.getMessage(),
+                    "Error",
+                    JOptionPane.ERROR_MESSAGE);
+        }
+    }
+}

--- a/java/envio/src/main/java/cl/prezdev/envio/SettingsDialog.java
+++ b/java/envio/src/main/java/cl/prezdev/envio/SettingsDialog.java
@@ -34,6 +34,11 @@ public class SettingsDialog extends JDialog {
         setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         setLayout(new BorderLayout(12, 12));
 
+        this.uiScaleSpinner = createUiScaleSpinner();
+        this.widthSpinner = createWidthSpinner();
+        this.heightSpinner = createHeightSpinner();
+        this.jsonEditor = createJsonEditor();
+
         JTabbedPane tabs = new JTabbedPane();
         tabs.addTab("Gráfico", createVisualPanel());
         tabs.addTab("JSON", createJsonPanel());
@@ -73,29 +78,18 @@ public class SettingsDialog extends JDialog {
 
         panel.add(new JLabel("Escala de interfaz"), gbc);
         gbc.gridx = 1;
-        uiScaleSpinner = new JSpinner(new SpinnerNumberModel((double) workingCopy.getUiScale(), 0.5, 2.5, 0.05));
-        workingCopy.setUiScale(((Double) uiScaleSpinner.getValue()).floatValue());
-        uiScaleSpinner.addChangeListener(spinnerListener(value -> workingCopy.setUiScale(value.floatValue())));
         panel.add(uiScaleSpinner, gbc);
 
         gbc.gridx = 0;
         gbc.gridy++;
         panel.add(new JLabel("Ancho de ventana"), gbc);
         gbc.gridx = 1;
-        int widthValue = Math.max(workingCopy.getWindowWidth(), 800);
-        widthSpinner = new JSpinner(new SpinnerNumberModel(widthValue, 400, 4096, 10));
-        workingCopy.setWindowWidth((Integer) widthSpinner.getValue());
-        widthSpinner.addChangeListener(spinnerListener(value -> workingCopy.setWindowWidth(value.intValue())));
         panel.add(widthSpinner, gbc);
 
         gbc.gridx = 0;
         gbc.gridy++;
         panel.add(new JLabel("Alto de ventana"), gbc);
         gbc.gridx = 1;
-        int heightValue = Math.max(workingCopy.getWindowHeight(), 600);
-        heightSpinner = new JSpinner(new SpinnerNumberModel(heightValue, 300, 2160, 10));
-        workingCopy.setWindowHeight((Integer) heightSpinner.getValue());
-        heightSpinner.addChangeListener(spinnerListener(value -> workingCopy.setWindowHeight(value.intValue())));
         panel.add(heightSpinner, gbc);
 
         gbc.gridx = 0;
@@ -132,12 +126,39 @@ public class SettingsDialog extends JDialog {
 
     private JPanel createJsonPanel() {
         JPanel panel = new JPanel(new BorderLayout());
-        jsonEditor = new JTextArea(20, 60);
-        jsonEditor.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
         panel.add(new JScrollPane(jsonEditor), BorderLayout.CENTER);
         JLabel infoLabel = new JLabel("Modifique el JSON y presione Guardar para aplicar los cambios.");
         panel.add(infoLabel, BorderLayout.SOUTH);
         return panel;
+    }
+
+    private JSpinner createUiScaleSpinner() {
+        JSpinner spinner = new JSpinner(new SpinnerNumberModel((double) workingCopy.getUiScale(), 0.5, 2.5, 0.05));
+        workingCopy.setUiScale(((Double) spinner.getValue()).floatValue());
+        spinner.addChangeListener(spinnerListener(value -> workingCopy.setUiScale(value.floatValue())));
+        return spinner;
+    }
+
+    private JSpinner createWidthSpinner() {
+        int widthValue = Math.max(workingCopy.getWindowWidth(), 800);
+        JSpinner spinner = new JSpinner(new SpinnerNumberModel(widthValue, 400, 4096, 10));
+        workingCopy.setWindowWidth((Integer) spinner.getValue());
+        spinner.addChangeListener(spinnerListener(value -> workingCopy.setWindowWidth(value.intValue())));
+        return spinner;
+    }
+
+    private JSpinner createHeightSpinner() {
+        int heightValue = Math.max(workingCopy.getWindowHeight(), 600);
+        JSpinner spinner = new JSpinner(new SpinnerNumberModel(heightValue, 300, 2160, 10));
+        workingCopy.setWindowHeight((Integer) spinner.getValue());
+        spinner.addChangeListener(spinnerListener(value -> workingCopy.setWindowHeight(value.intValue())));
+        return spinner;
+    }
+
+    private JTextArea createJsonEditor() {
+        JTextArea editor = new JTextArea(20, 60);
+        editor.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
+        return editor;
     }
 
     private ChangeListener spinnerListener(Consumer<Number> consumer) {

--- a/java/envio/src/main/java/cl/prezdev/envio/SettingsDialog.java
+++ b/java/envio/src/main/java/cl/prezdev/envio/SettingsDialog.java
@@ -10,6 +10,7 @@ import java.awt.*;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -23,13 +24,15 @@ public class SettingsDialog extends JDialog {
     private final JSpinner widthSpinner;
     private final JSpinner heightSpinner;
     private final JTextArea jsonEditor;
+    private final Path settingsPath;
     private final ObjectMapper mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
 
-    public SettingsDialog(Frame owner, Settings settings, Consumer<Settings> onApply) {
+    public SettingsDialog(Frame owner, Settings settings, Path settingsPath, Consumer<Settings> onApply) {
         super(owner, "Ajustes", true);
         this.settings = settings;
         this.workingCopy = settings.copy();
         this.onApply = onApply;
+        this.settingsPath = settingsPath;
 
         setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         setLayout(new BorderLayout(12, 12));
@@ -127,8 +130,14 @@ public class SettingsDialog extends JDialog {
     private JPanel createJsonPanel() {
         JPanel panel = new JPanel(new BorderLayout());
         panel.add(new JScrollPane(jsonEditor), BorderLayout.CENTER);
-        JLabel infoLabel = new JLabel("Modifique el JSON y presione Guardar para aplicar los cambios.");
-        panel.add(infoLabel, BorderLayout.SOUTH);
+
+        JPanel infoPanel = new JPanel(new GridLayout(0, 1));
+        infoPanel.add(new JLabel("Modifique el JSON y presione Guardar para aplicar los cambios."));
+        if (settingsPath != null) {
+            infoPanel.add(new JLabel("Archivo de configuración: " + settingsPath));
+        }
+
+        panel.add(infoPanel, BorderLayout.SOUTH);
         return panel;
     }
 

--- a/java/envio/src/main/java/cl/prezdev/envio/SettingsManager.java
+++ b/java/envio/src/main/java/cl/prezdev/envio/SettingsManager.java
@@ -1,0 +1,66 @@
+package cl.prezdev.envio;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class SettingsManager {
+    private static final String DIRECTORY_NAME = ".envio";
+    private static final String FILE_NAME = "settings.json";
+
+    private final ObjectMapper mapper;
+    private final Path settingsPath;
+
+    public SettingsManager() {
+        this(Paths.get(System.getProperty("user.home"), DIRECTORY_NAME, FILE_NAME));
+    }
+
+    public SettingsManager(Path settingsPath) {
+        this.mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+        this.settingsPath = settingsPath;
+    }
+
+    public Settings load() {
+        if (Files.exists(settingsPath)) {
+            try {
+                return mapper.readValue(settingsPath.toFile(), Settings.class);
+            } catch (IOException ex) {
+                System.err.println("No se pudieron cargar los ajustes: " + ex.getMessage());
+            }
+        }
+        return Settings.defaults();
+    }
+
+    public void save(Settings settings) {
+        try {
+            Path directory = settingsPath.getParent();
+            if (directory != null && !Files.exists(directory)) {
+                Files.createDirectories(directory);
+            }
+            mapper.writeValue(settingsPath.toFile(), settings);
+        } catch (IOException ex) {
+            System.err.println("No se pudieron guardar los ajustes: " + ex.getMessage());
+        }
+    }
+
+    public Path getSettingsPath() {
+        return settingsPath;
+    }
+
+    public String toJson(Settings settings) {
+        try {
+            return mapper.writeValueAsString(settings);
+        } catch (JsonProcessingException e) {
+            return "{}";
+        }
+    }
+
+    public Settings fromJson(String json) throws IOException {
+        return mapper.readValue(json, Settings.class);
+    }
+}


### PR DESCRIPTION
## Summary
- load and persist UI scale, window size, and component zoom settings to a settings.json file
- add Settings dialog with graphical controls and raw JSON editor to update saved values
- integrate HttpClientPanel with the stored settings and update the menu handling for scale changes

## Testing
- mvn -q -DskipTests package *(fails: Forbidden 403 when downloading Maven resources plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68e5e8003b048328949f3a67a5ef24dc